### PR TITLE
Add missing translation keys and multi-language localization

### DIFF
--- a/src/main/java/net/felixlotionstein/betterbeginnings/BetterBeginningsEvents.java
+++ b/src/main/java/net/felixlotionstein/betterbeginnings/BetterBeginningsEvents.java
@@ -57,7 +57,7 @@ public class BetterBeginningsEvents {
                 event.setCanceled(true);
 
                 if (Config.SEND_MESSAGES.get()) {
-                    player.sendSystemMessage(Component.literal("You need at least a stone hatchet to chop wood!"));
+                    player.sendSystemMessage(Component.translatable("message.betterbeginnings.need_hatchet"));
                 }
             }
         }
@@ -67,7 +67,7 @@ public class BetterBeginningsEvents {
                 event.setCanceled(true);
 
                 if (Config.SEND_MESSAGES.get()) {
-                    player.sendSystemMessage(Component.literal("You need a copper tool to mine this!"));
+                    player.sendSystemMessage(Component.translatable("message.betterbeginnings.need_copper_tool"));
                 }
             }
         }
@@ -77,7 +77,7 @@ public class BetterBeginningsEvents {
                 event.setCanceled(true);
 
                 if (Config.SEND_MESSAGES.get()) {
-                    player.sendSystemMessage(Component.literal("You need an iron tool to mine this!"));
+                    player.sendSystemMessage(Component.translatable("message.betterbeginnings.need_iron_tool"));
                 }
             }
         }

--- a/src/main/resources/assets/betterbeginnings/lang/en_us.json
+++ b/src/main/resources/assets/betterbeginnings/lang/en_us.json
@@ -1,11 +1,14 @@
 {
-  "item.betterbeginnings.rock": "Rock",
   "block.betterbeginnings.rock_block": "Rock",
+  "item.betterbeginnings.rock_block": "Rock",
   "item.betterbeginnings.stone_hatchet": "Stone Hatchet",
   "item.betterbeginnings.copper_axe": "Copper Axe",
   "item.betterbeginnings.copper_pickaxe": "Copper Pickaxe",
   "item.betterbeginnings.copper_shovel": "Copper Shovel",
   "item.betterbeginnings.copper_sword": "Copper Sword",
   "item.betterbeginnings.copper_hoe": "Copper Hoe",
-  "item.betterbeginnings.firestarter": "Firestarter"
+  "item.betterbeginnings.firestarter": "Firestarter",
+  "message.betterbeginnings.need_hatchet": "You need at least a stone hatchet to chop wood!",
+  "message.betterbeginnings.need_copper_tool": "You need a copper tool to mine this!",
+  "message.betterbeginnings.need_iron_tool": "You need an iron tool to mine this!"
 }

--- a/src/main/resources/assets/betterbeginnings/lang/es_es.json
+++ b/src/main/resources/assets/betterbeginnings/lang/es_es.json
@@ -1,0 +1,14 @@
+{
+  "block.betterbeginnings.rock_block": "Roca",
+  "item.betterbeginnings.rock_block": "Roca",
+  "item.betterbeginnings.stone_hatchet": "Hachuela de piedra",
+  "item.betterbeginnings.copper_axe": "Hacha de cobre",
+  "item.betterbeginnings.copper_pickaxe": "Pico de cobre",
+  "item.betterbeginnings.copper_shovel": "Pala de cobre",
+  "item.betterbeginnings.copper_sword": "Espada de cobre",
+  "item.betterbeginnings.copper_hoe": "Azada de cobre",
+  "item.betterbeginnings.firestarter": "Encendedor",
+  "message.betterbeginnings.need_hatchet": "¡Necesitas al menos una hachuela de piedra para cortar madera!",
+  "message.betterbeginnings.need_copper_tool": "¡Necesitas una herramienta de cobre para extraer este bloque!",
+  "message.betterbeginnings.need_iron_tool": "¡Necesitas una herramienta de hierro para extraer este bloque!"
+}

--- a/src/main/resources/assets/betterbeginnings/lang/fr_fr.json
+++ b/src/main/resources/assets/betterbeginnings/lang/fr_fr.json
@@ -1,0 +1,14 @@
+{
+  "block.betterbeginnings.rock_block": "Caillou",
+  "item.betterbeginnings.rock_block": "Caillou",
+  "item.betterbeginnings.stone_hatchet": "Hachette en pierre",
+  "item.betterbeginnings.copper_axe": "Hache en cuivre",
+  "item.betterbeginnings.copper_pickaxe": "Pioche en cuivre",
+  "item.betterbeginnings.copper_shovel": "Pelle en cuivre",
+  "item.betterbeginnings.copper_sword": "Épée en cuivre",
+  "item.betterbeginnings.copper_hoe": "Houe en cuivre",
+  "item.betterbeginnings.firestarter": "Allume-feu",
+  "message.betterbeginnings.need_hatchet": "Il vous faut au moins une hachette en pierre pour couper du bois !",
+  "message.betterbeginnings.need_copper_tool": "Il vous faut un outil en cuivre pour extraire ce bloc !",
+  "message.betterbeginnings.need_iron_tool": "Il vous faut un outil en fer pour extraire ce bloc !"
+}

--- a/src/main/resources/assets/betterbeginnings/lang/pl_pl.json
+++ b/src/main/resources/assets/betterbeginnings/lang/pl_pl.json
@@ -1,0 +1,14 @@
+{
+  "block.betterbeginnings.rock_block": "Kamień",
+  "item.betterbeginnings.rock_block": "Kamień",
+  "item.betterbeginnings.stone_hatchet": "Kamienny toporek",
+  "item.betterbeginnings.copper_axe": "Miedziana siekiera",
+  "item.betterbeginnings.copper_pickaxe": "Miedziany kilof",
+  "item.betterbeginnings.copper_shovel": "Miedziana łopata",
+  "item.betterbeginnings.copper_sword": "Miedziany miecz",
+  "item.betterbeginnings.copper_hoe": "Miedziana motyka",
+  "item.betterbeginnings.firestarter": "Rozpałka",
+  "message.betterbeginnings.need_hatchet": "Potrzebujesz co najmniej kamiennego toporka, aby ścinać drewno!",
+  "message.betterbeginnings.need_copper_tool": "Potrzebujesz miedzianego narzędzia, aby wydobyć ten blok!",
+  "message.betterbeginnings.need_iron_tool": "Potrzebujesz żelaznego narzędzia, aby wydobyć ten blok!"
+}

--- a/src/main/resources/assets/betterbeginnings/lang/ru_ru.json
+++ b/src/main/resources/assets/betterbeginnings/lang/ru_ru.json
@@ -1,0 +1,14 @@
+{
+  "block.betterbeginnings.rock_block": "Камень",
+  "item.betterbeginnings.rock_block": "Камень",
+  "item.betterbeginnings.stone_hatchet": "Каменный топорик",
+  "item.betterbeginnings.copper_axe": "Медный топор",
+  "item.betterbeginnings.copper_pickaxe": "Медная кирка",
+  "item.betterbeginnings.copper_shovel": "Медная лопата",
+  "item.betterbeginnings.copper_sword": "Медный меч",
+  "item.betterbeginnings.copper_hoe": "Медная мотыга",
+  "item.betterbeginnings.firestarter": "Разжигатель",
+  "message.betterbeginnings.need_hatchet": "Нужен хотя бы каменный топорик, чтобы рубить дерево!",
+  "message.betterbeginnings.need_copper_tool": "Для добычи нужен медный инструмент!",
+  "message.betterbeginnings.need_iron_tool": "Для добычи нужен железный инструмент!"
+}


### PR DESCRIPTION
## Summary
- Wire tool-gate messages through translation keys instead of hardcoded English strings
- Add localizations: `ru_ru`, `es_es`, `fr_fr`, `pl_pl`
- Fix incorrect `rock` lang key to match registered `rock_block`